### PR TITLE
Add publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,28 @@
+name: Upload to PyPI
+
+on:
+  push:
+    tags: [ 'v*' ]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: setup python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+      - name: install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: build
+        run:
+          python setup.py sdist bdist_wheel
+      - name: publish
+        env:
+          TWINE_USERNAME: ${{ secrets.PYPI_API_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+        run:
+          twine upload dist/*


### PR DESCRIPTION
Adds an automated publishing github workflow to upload to pypi for all 'v*' tags. Currently won't work because only @samkohn has access to the project. Once we get access, we can update the `PYPI_API_USERNAME` and `PYPI_API_TOKEN` secrets within the github project settings.

@drinkingkazu might be interested in tracking this.